### PR TITLE
clocky - an example of binding an atom

### DIFF
--- a/clocky/.gitignore
+++ b/clocky/.gitignore
@@ -1,0 +1,13 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-cljsbuild*
+public/out
+*~

--- a/clocky/README.md
+++ b/clocky/README.md
@@ -1,0 +1,9 @@
+# clocky
+
+c2 svg animation.
+
+Try:
+
+lein cljsbuild auto
+
+And then open public/index.html + start editing core.cljs

--- a/clocky/project.clj
+++ b/clocky/project.clj
@@ -1,0 +1,18 @@
+(defproject clocky "0.0.1-SNAPSHOT"
+  :description "clocky: c2 animating svg"
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [com.keminglabs/c2 "0.2.1"]]
+  :min-lein-version "2.0.0"
+  :source-paths ["src/clj"]
+
+  :plugins [[lein-cljsbuild "0.2.7"]]
+
+  :cljsbuild {
+    :builds [{
+      :source-path "src/cljs"
+      :compiler {
+        :output-to "public/out/clocky.js"
+        ;:optimizations :whitespace
+        ;:pretty-print true 
+        :optimizations :advanced
+        }}]})

--- a/clocky/public/assets/base.css
+++ b/clocky/public/assets/base.css
@@ -1,9 +1,9 @@
-body { background-color:grey;}
-path.millis1 { fill:brown;}
-path.millis2 { fill:pink;}
-path.seconds1 { fill:cornflowerblue;}
-path.seconds2 { fill:blue;}
-path.minutes1 { fill:darkslateblue;}
-path.minutes2 { fill:purple;}
-path.hours1 { fill:navy;}
-path.hours2 { fill:darkorange;}
+body { background-color:grey; }
+path.millis1 { stroke-width:1; stroke:pink; fill:brown; }
+path.millis2 { stroke:brown; fill:pink; }
+path.seconds1 { stroke:pink; fill:brown; }
+path.seconds2 { stroke:brown; fill:pink; }
+path.minutes1 { stroke:pink; fill:brown; }
+path.minutes2 { stroke:brown; fill:pink; }
+path.hours1 { stroke:pink; fill:brown; }
+path.hours2 { stroke:brown; fill:pink; }

--- a/clocky/public/assets/base.css
+++ b/clocky/public/assets/base.css
@@ -1,0 +1,9 @@
+body { background-color:grey;}
+path.millis1 { fill:brown;}
+path.millis2 { fill:pink;}
+path.seconds1 { fill:cornflowerblue;}
+path.seconds2 { fill:blue;}
+path.minutes1 { fill:darkslateblue;}
+path.minutes2 { fill:purple;}
+path.hours1 { fill:navy;}
+path.hours2 { fill:darkorange;}

--- a/clocky/public/assets/rAF.js
+++ b/clocky/public/assets/rAF.js
@@ -1,0 +1,33 @@
+//
+// source: https://gist.github.com/1579671
+//
+// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
+
+// requestAnimationFrame polyfill by Erik Möller
+// fixes from Paul Irish and Tino Zijdel
+
+(function() {
+    var lastTime = 0;
+    var vendors = ['ms', 'moz', 'webkit', 'o'];
+    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+        window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+        window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] 
+                                   || window[vendors[x]+'CancelRequestAnimationFrame'];
+    }
+ 
+    if (!window.requestAnimationFrame)
+        window.requestAnimationFrame = function(callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); }, 
+              timeToCall);
+            lastTime = currTime + timeToCall;
+            return id;
+        };
+ 
+    if (!window.cancelAnimationFrame)
+        window.cancelAnimationFrame = function(id) {
+            clearTimeout(id);
+        };
+}());

--- a/clocky/public/index.html
+++ b/clocky/public/index.html
@@ -1,10 +1,12 @@
 <html>
-<head><title>Clocky</title></head>
+<head>
+  <title>Clocky</title>
   <link rel="stylesheet" href="assets/base.css">
+</head>
 <body>
-<svg id="clocky">
-<!-- this is where the magic happens -->
-</svg>
-<script type="text/javascript" src="assets/rAF.js"></script>
-<script type="text/javascript" src="out/clocky.js"></script>
+  <svg id="clocky">
+  <!-- this is where the magic happens -->
+  </svg>
+  <script type="text/javascript" src="assets/rAF.js"></script>
+  <script type="text/javascript" src="out/clocky.js"></script>
 </body> </html>

--- a/clocky/public/index.html
+++ b/clocky/public/index.html
@@ -1,0 +1,10 @@
+<html>
+<head><title>Clocky</title></head>
+  <link rel="stylesheet" href="assets/base.css">
+<body>
+<svg id="clocky">
+<!-- this is where the magic happens -->
+</svg>
+<script type="text/javascript" src="assets/rAF.js"></script>
+<script type="text/javascript" src="out/clocky.js"></script>
+</body> </html>

--- a/clocky/src/cljs/clocky/core.cljs
+++ b/clocky/src/cljs/clocky/core.cljs
@@ -15,7 +15,7 @@
 (bind! "#clocky" 
   [:svg
     [:g {:transform "translate(300,300)rotate(-90)"}
-      (for [k [:hours :minutes :seconds :millis]]
+      (doall (for [k [:hours :minutes :seconds :millis]]
         (let [v      (get @clock-atom k)
               angle1 (/ (* Tau v) 100)
               angle2 (+ angle1 Pi)
@@ -29,7 +29,7 @@
             [:path {:class (str (name k) "2")
                     :d (arc :outer-radius radius
                             :start-angle angle2
-                            :end-angle   angle3)}]]))]])
+                            :end-angle   angle3)}]])))]])
 
 (defn nextloop []
   (let [d (js/Date.)]

--- a/clocky/src/cljs/clocky/core.cljs
+++ b/clocky/src/cljs/clocky/core.cljs
@@ -8,9 +8,9 @@
 
 (def clock-atom
   "clock data bound to atom. each number is a percentage."
-  (atom {"hours" 50, "minutes" 60, "seconds" 70, "millis" 80}))
+  (atom (array-map :hours 50, :minutes 60, :seconds 70, :millis 80)))
 
-(def radii {"hours" 275, "minutes" 200, "seconds" 110, "millis", 30})
+(def radii {:hours 275, :minutes 200, :seconds 110, :millis, 30})
 
 (bind! "#clocky" 
   [:svg
@@ -22,22 +22,22 @@
                     angle3 (+ angle2 Pi)
                     radius (radii label)]
                 [:g.slice
-                  [:path {:class (str label "1")
+                  [:path {:class (str (name label) "1")
                           :d (arc :outer-radius radius
                                   :start-angle angle1
                                   :end-angle   angle2)}]
-                  [:path {:class (str label "2")
+                  [:path {:class (str (name label) "2")
                           :d (arc :outer-radius radius
                                   :start-angle angle2
                                   :end-angle   angle3)}]])))]])
 
 (defn nextloop []
   (let [d (js/Date.)]
-    (reset! clock-atom 
-      {"hours"   (/ (* (rem (.getHours d) 12) 100) 12)
-       "minutes" (/ (* (.getMinutes d) 100) 60)
-       "seconds" (/ (* (.getSeconds d) 100) 60)
-       "millis"  (/ (* (.getMilliseconds d) 100) 1000)})))
+    (reset! clock-atom
+      (array-map :hours   (/ (* (rem (.getHours d) 12) 100) 12)
+                 :minutes (/ (* (.getMinutes d) 100) 60)
+                 :seconds (/ (* (.getSeconds d) 100) 60)
+                 :millis  (/ (* (.getMilliseconds d) 100) 1000)))))
 
 (defn animation-loop []
   (.requestAnimationFrame (dom/getWindow) animation-loop)

--- a/clocky/src/cljs/clocky/core.cljs
+++ b/clocky/src/cljs/clocky/core.cljs
@@ -8,36 +8,36 @@
 
 (def clock-atom
   "clock data bound to atom. each number is a percentage."
-  (atom (array-map :hours 50, :minutes 60, :seconds 70, :millis 80)))
+  (atom {:hours 50, :minutes 60, :seconds 70, :millis 80}))
 
 (def radii {:hours 275, :minutes 200, :seconds 110, :millis, 30})
 
 (bind! "#clocky" 
   [:svg
-   [:g {:transform "translate(300,300)rotate(-90)"}
-    (unify @clock-atom
-           (fn [[label val]]
-              (let [angle1 (/ (* Tau val) 100)
-                    angle2 (+ angle1 Pi)
-                    angle3 (+ angle2 Pi)
-                    radius (radii label)]
-                [:g.slice
-                  [:path {:class (str (name label) "1")
-                          :d (arc :outer-radius radius
-                                  :start-angle angle1
-                                  :end-angle   angle2)}]
-                  [:path {:class (str (name label) "2")
-                          :d (arc :outer-radius radius
-                                  :start-angle angle2
-                                  :end-angle   angle3)}]])))]])
+    [:g {:transform "translate(300,300)rotate(-90)"}
+      (for [k [:hours :minutes :seconds :millis]]
+        (let [v      (get @clock-atom k)
+              angle1 (/ (* Tau v) 100)
+              angle2 (+ angle1 Pi)
+              angle3 (+ angle2 Pi)
+              radius (get radii k)]
+          [:g.slice
+            [:path {:class (str (name k) "1")
+                    :d (arc :outer-radius radius
+                            :start-angle angle1
+                            :end-angle   angle2)}]
+            [:path {:class (str (name k) "2")
+                    :d (arc :outer-radius radius
+                            :start-angle angle2
+                            :end-angle   angle3)}]]))]])
 
 (defn nextloop []
   (let [d (js/Date.)]
-    (reset! clock-atom
-      (array-map :hours   (/ (* (rem (.getHours d) 12) 100) 12)
-                 :minutes (/ (* (.getMinutes d) 100) 60)
-                 :seconds (/ (* (.getSeconds d) 100) 60)
-                 :millis  (/ (* (.getMilliseconds d) 100) 1000)))))
+    (reset! clock-atom 
+      {:hours   (/ (* (rem (.getHours d) 12) 100) 12)
+       :minutes (/ (* (.getMinutes d) 100) 60)
+       :seconds (/ (* (.getSeconds d) 100) 60)
+       :millis  (/ (* (.getMilliseconds d) 100) 1000)})))
 
 (defn animation-loop []
   (.requestAnimationFrame (dom/getWindow) animation-loop)

--- a/clocky/src/cljs/clocky/core.cljs
+++ b/clocky/src/cljs/clocky/core.cljs
@@ -1,0 +1,47 @@
+(ns clocky.core
+  (:use-macros [c2.util :only [bind!]])
+  (:use [c2.core :only [unify]]
+        [c2.maths :only [Tau Pi]]
+        [c2.svg :only [arc]])
+  (:require [c2.scale :as scale]
+            [goog.dom :as dom]))
+
+(def clock-atom
+  "clock data bound to atom. each number is a percentage."
+  (atom {"hours" 50, "minutes" 60, "seconds" 70, "millis" 80}))
+
+(def radii {"hours" 275, "minutes" 200, "seconds" 110, "millis", 30})
+
+(bind! "#clocky" 
+  [:svg
+   [:g {:transform "translate(300,300)rotate(-90)"}
+    (unify @clock-atom
+           (fn [[label val]]
+              (let [angle1 (/ (* Tau val) 100)
+                    angle2 (+ angle1 Pi)
+                    angle3 (+ angle2 Pi)
+                    radius (radii label)]
+                [:g.slice
+                  [:path {:class (str label "1")
+                          :d (arc :outer-radius radius
+                                  :start-angle angle1
+                                  :end-angle   angle2)}]
+                  [:path {:class (str label "2")
+                          :d (arc :outer-radius radius
+                                  :start-angle angle2
+                                  :end-angle   angle3)}]])))]])
+
+(defn nextloop []
+  (let [d (js/Date.)
+        h {}
+        h (assoc h "hours"   (/ (* (rem (.getHours d) 12) 100) 12))
+        h (assoc h "minutes" (/ (* (.getMinutes d) 100) 60))
+        h (assoc h "seconds" (/ (* (.getSeconds d) 100) 60))
+        h (assoc h "millis"  (/ (* (.getMilliseconds d) 100) 1000))]
+  (reset! clock-atom h)))
+
+(defn animation-loop []
+  (.requestAnimationFrame (dom/getWindow) animation-loop)
+  (nextloop))
+
+(animation-loop)

--- a/clocky/src/cljs/clocky/core.cljs
+++ b/clocky/src/cljs/clocky/core.cljs
@@ -32,13 +32,12 @@
                                   :end-angle   angle3)}]])))]])
 
 (defn nextloop []
-  (let [d (js/Date.)
-        h {}
-        h (assoc h "hours"   (/ (* (rem (.getHours d) 12) 100) 12))
-        h (assoc h "minutes" (/ (* (.getMinutes d) 100) 60))
-        h (assoc h "seconds" (/ (* (.getSeconds d) 100) 60))
-        h (assoc h "millis"  (/ (* (.getMilliseconds d) 100) 1000))]
-  (reset! clock-atom h)))
+  (let [d (js/Date.)]
+    (reset! clock-atom 
+      {"hours"   (/ (* (rem (.getHours d) 12) 100) 12)
+       "minutes" (/ (* (.getMinutes d) 100) 60)
+       "seconds" (/ (* (.getSeconds d) 100) 60)
+       "millis"  (/ (* (.getMilliseconds d) 100) 1000)})))
 
 (defn animation-loop []
   (.requestAnimationFrame (dom/getWindow) animation-loop)


### PR DESCRIPTION
Little toy radial clock serves as an example of c2 bind!/unify with atoms and how to animate by resetting the atom. Note that this depends on an included javascript polyfill for requestAnimationFrame and currently doesn't render correctly under firefox (works well in webkit, including mobile safari and chrome).
